### PR TITLE
ECO-697: convert some lib methods to take &str args

### DIFF
--- a/client/lib/balance.rs
+++ b/client/lib/balance.rs
@@ -1,7 +1,0 @@
-use casper_node::rpcs::{state::GetBalance, RpcWithParams};
-
-use crate::rpc::RpcClient;
-
-impl RpcClient for GetBalance {
-    const RPC_METHOD: &'static str = Self::METHOD;
-}

--- a/client/lib/block.rs
+++ b/client/lib/block.rs
@@ -1,7 +1,0 @@
-use casper_node::rpcs::{chain::GetBlock, RpcWithOptionalParams};
-
-use crate::rpc::RpcClient;
-
-impl RpcClient for GetBlock {
-    const RPC_METHOD: &'static str = Self::METHOD;
-}

--- a/client/lib/get_state_hash.rs
+++ b/client/lib/get_state_hash.rs
@@ -1,7 +1,0 @@
-use casper_node::rpcs::{chain::GetStateRootHash, RpcWithOptionalParams};
-
-use crate::rpc::RpcClient;
-
-impl RpcClient for GetStateRootHash {
-    const RPC_METHOD: &'static str = Self::METHOD;
-}

--- a/client/lib/lib.rs
+++ b/client/lib/lib.rs
@@ -12,18 +12,158 @@
     unused_qualifications
 )]
 
-mod balance;
-mod block;
 pub mod cl_type;
 mod deploy;
 mod error;
 mod executable_deploy_item_ext;
-mod get_state_hash;
 pub mod keygen;
-mod query_state;
 mod rpc;
+
+use jsonrpc_lite::JsonRpc;
 
 pub use deploy::{DeployExt, DeployParams};
 pub use error::Error;
+use error::Result;
 pub use executable_deploy_item_ext::ExecutableDeployItemExt;
 pub use rpc::{RpcCall, TransferTarget};
+
+/// Gets a `Deploy` from the node.
+///
+/// * `maybe_rpc_id` is used for RPC-ID as required by the JSON-RPC specification, and is returned
+///   by the node in the corresponding response.  It must be either able to be parsed as a `u32` or
+///   empty.  If empty, a random ID will be assigned.
+/// * `node_address` identifies the network address of the target node's HTTP server, e.g.
+///   `"http://127.0.0.1:7777"`.
+/// * When `verbose` is `true`, the request will be printed to `stdout`.
+/// * `deploy_hash` must be a hex-encoded, 32-byte hash digest.
+pub fn get_deploy(
+    maybe_rpc_id: &str,
+    node_address: &str,
+    verbose: bool,
+    deploy_hash: &str,
+) -> Result<JsonRpc> {
+    RpcCall::new(maybe_rpc_id, node_address, verbose)?.get_deploy(deploy_hash)
+}
+
+/// Queries the node for an item at the given state root hash, under the given key and path.
+///
+/// * `maybe_rpc_id` is used for RPC-ID as required by the JSON-RPC specification, and is returned
+///   by the node in the corresponding response.  It must be either able to be parsed as a `u32` or
+///   empty.  If empty, a random ID will be assigned.
+/// * `node_address` identifies the network address of the target node's HTTP server, e.g.
+///   `"http://127.0.0.1:7777"`.
+/// * When `verbose` is `true`, the request will be printed to `stdout`.
+/// * `state_root_hash` must be a hex-encoded, 32-byte hash digest.
+/// * `key` must be a formatted [`PublicKey`](casper_node::crypto::asymmetric_key::PublicKey) or
+///   [`Key`](casper_types::Key).  This will take the form of e.g.
+///       * `01c9e33693951aaac23c49bee44ad6f863eedcd38c084a3a8f11237716a3df9c2c` or
+///       * `account-hash-0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20` or
+///       * `hash-0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20` or
+///       * `uref-0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20-007`
+/// * `path` is comprised of components starting from the `key`, separated by `/`s.
+pub fn get_item(
+    maybe_rpc_id: &str,
+    node_address: &str,
+    verbose: bool,
+    state_root_hash: &str,
+    key: &str,
+    path: &str,
+) -> Result<JsonRpc> {
+    RpcCall::new(maybe_rpc_id, node_address, verbose)?.get_item(state_root_hash, key, path)
+}
+
+/// Queries the node for a state root hash at a given `Block`.
+///
+/// * `maybe_rpc_id` is used for RPC-ID as required by the JSON-RPC specification, and is returned
+///   by the node in the corresponding response.  It must be either able to be parsed as a `u32` or
+///   empty.  If empty, a random ID will be assigned.
+/// * `node_address` identifies the network address of the target node's HTTP server, e.g.
+///   `"http://127.0.0.1:7777"`.
+/// * When `verbose` is `true`, the request will be printed to `stdout`.
+/// * `maybe_block_hash` must be a hex-encoded, 32-byte hash digest or empty.  If empty, the latest
+///   block will be used.
+pub fn get_state_root_hash(
+    maybe_rpc_id: &str,
+    node_address: &str,
+    verbose: bool,
+    maybe_block_hash: &str,
+) -> Result<JsonRpc> {
+    RpcCall::new(maybe_rpc_id, node_address, verbose)?.get_state_root_hash(maybe_block_hash)
+}
+
+/// Gets the balance from a purse.
+///
+/// * `maybe_rpc_id` is used for RPC-ID as required by the JSON-RPC specification, and is returned
+///   by the node in the corresponding response.  It must be either able to be parsed as a `u32` or
+///   empty.  If empty, a random ID will be assigned.
+/// * `node_address` identifies the network address of the target node's HTTP server, e.g.
+///   `"http://127.0.0.1:7777"`.
+/// * When `verbose` is `true`, the request will be printed to `stdout`.
+/// * `state_root_hash` must be a hex-encoded, 32-byte hash digest.
+/// * `purse_uref` must be a formatted URef as obtained with `get_item`.  This will take the form of
+///   e.g. `uref-0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20-007`
+pub fn get_balance(
+    maybe_rpc_id: &str,
+    node_address: &str,
+    verbose: bool,
+    state_root_hash: &str,
+    purse_uref: &str,
+) -> Result<JsonRpc> {
+    RpcCall::new(maybe_rpc_id, node_address, verbose)?.get_balance(state_root_hash, purse_uref)
+}
+
+/// Reads a previously-saved `Deploy` from file, and sends that to the node.
+///
+/// * `maybe_rpc_id` is used for RPC-ID as required by the JSON-RPC specification, and is returned
+///   by the node in the corresponding response.  It must be either able to be parsed as a `u32` or
+///   empty.  If empty, a random ID will be assigned.
+/// * `node_address` identifies the network address of the target node's HTTP server, e.g.
+///   `"http://127.0.0.1:7777"`.
+/// * When `verbose` is `true`, the request will be printed to `stdout`.
+/// * `input_path` is the path to the file to read.
+pub fn send_deploy_file(
+    maybe_rpc_id: &str,
+    node_address: &str,
+    verbose: bool,
+    input_path: &str,
+) -> Result<JsonRpc> {
+    RpcCall::new(maybe_rpc_id, node_address, verbose)?.send_deploy_file(input_path)
+}
+
+/// Lists `Deploy`s included in the specified `Block`.
+///
+/// * `maybe_rpc_id` is used for RPC-ID as required by the JSON-RPC specification, and is returned
+///   by the node in the corresponding response.  It must be either able to be parsed as a `u32` or
+///   empty.  If empty, a random ID will be assigned.
+/// * `node_address` identifies the network address of the target node's HTTP server, e.g.
+///   `"http://127.0.0.1:7777"`.
+/// * When `verbose` is `true`, the request will be printed to `stdout`.
+/// * `maybe_block_hash` must be a hex-encoded, 32-byte hash digest or empty.  If empty, the latest
+///   block will be used.
+pub fn list_deploys(
+    maybe_rpc_id: &str,
+    node_address: &str,
+    verbose: bool,
+    maybe_block_hash: &str,
+) -> Result<JsonRpc> {
+    RpcCall::new(maybe_rpc_id, node_address, verbose)?.list_deploys(maybe_block_hash)
+}
+
+/// Gets a `Block` from the node.
+///
+/// * `maybe_rpc_id` is used for RPC-ID as required by the JSON-RPC specification, and is returned
+///   by the node in the corresponding response.  It must be either able to be parsed as a `u32` or
+///   empty.  If empty, a random ID will be assigned.
+/// * `node_address` identifies the network address of the target node's HTTP server, e.g.
+///   `"http://127.0.0.1:7777"`.
+/// * When `verbose` is `true`, the request will be printed to `stdout`.
+/// * `maybe_block_hash` must be a hex-encoded, 32-byte hash digest or empty.  If empty, the latest
+///   block will be retrieved.
+pub fn get_block(
+    maybe_rpc_id: &str,
+    node_address: &str,
+    verbose: bool,
+    maybe_block_hash: &str,
+) -> Result<JsonRpc> {
+    RpcCall::new(maybe_rpc_id, node_address, verbose)?.get_block(maybe_block_hash)
+}

--- a/client/lib/query_state.rs
+++ b/client/lib/query_state.rs
@@ -1,7 +1,0 @@
-use casper_node::rpcs::{state::GetItem, RpcWithParams};
-
-use crate::rpc::RpcClient;
-
-impl RpcClient for GetItem {
-    const RPC_METHOD: &'static str = <Self as RpcWithParams>::METHOD;
-}

--- a/client/src/block/get.rs
+++ b/client/src/block/get.rs
@@ -31,12 +31,14 @@ impl<'a, 'b> ClientCommand<'a, 'b> for GetBlock {
     }
 
     fn run(matches: &ArgMatches<'_>) {
-        let rpc = common::rpc(matches);
-
+        let maybe_rpc_id = common::rpc_id::get(matches);
+        let node_address = common::node_address::get(matches);
+        let verbose = common::verbose::get(matches);
         let maybe_block_hash = common::block_hash::get(matches);
-        let response = rpc
-            .get_block(maybe_block_hash)
-            .unwrap_or_else(|error| panic!("response error: {}", error));
+
+        let response =
+            casper_client::get_block(maybe_rpc_id, node_address, verbose, maybe_block_hash)
+                .unwrap_or_else(|error| panic!("response error: {}", error));
         println!(
             "{}",
             serde_json::to_string_pretty(&response).expect("should encode to JSON")

--- a/client/src/deploy/creation_common.rs
+++ b/client/src/deploy/creation_common.rs
@@ -892,11 +892,10 @@ pub(super) mod input {
             .display_order(DisplayOrder::Input as usize)
     }
 
-    pub fn get(matches: &ArgMatches) -> String {
+    pub fn get<'a>(matches: &'a ArgMatches) -> &'a str {
         matches
             .value_of(ARG_NAME)
             .unwrap_or_else(|| panic!("should have {} arg", ARG_NAME))
-            .to_string()
     }
 }
 

--- a/client/src/deploy/list.rs
+++ b/client/src/deploy/list.rs
@@ -55,13 +55,14 @@ impl<'a, 'b> ClientCommand<'a, 'b> for ListDeploys {
     }
 
     fn run(matches: &ArgMatches<'_>) {
-        let rpc = common::rpc(matches);
-
+        let maybe_rpc_id = common::rpc_id::get(matches);
+        let node_address = common::node_address::get(matches);
+        let verbose = common::verbose::get(matches);
         let maybe_block_hash = common::block_hash::get(matches);
 
-        let response_value = rpc
-            .list_deploys(maybe_block_hash)
-            .unwrap_or_else(|error| panic!("should parse as a GetBlockResult: {}", error));
+        let response_value =
+            casper_client::list_deploys(maybe_rpc_id, node_address, verbose, maybe_block_hash)
+                .unwrap_or_else(|error| panic!("should parse as a GetBlockResult: {}", error));
         println!(
             "{}",
             serde_json::to_string_pretty(&response_value).expect("should encode to JSON")

--- a/client/src/deploy/send.rs
+++ b/client/src/deploy/send.rs
@@ -22,12 +22,14 @@ impl<'a, 'b> ClientCommand<'a, 'b> for SendDeploy {
     }
 
     fn run(matches: &ArgMatches<'_>) {
-        let rpc = common::rpc(matches);
-
+        let maybe_rpc_id = common::rpc_id::get(matches);
+        let node_address = common::node_address::get(matches);
+        let verbose = common::verbose::get(matches);
         let input_path = creation_common::input::get(matches);
-        let response = rpc
-            .send_deploy_file(&input_path)
-            .unwrap_or_else(|error| panic!("response error: {}", error));
+
+        let response =
+            casper_client::send_deploy_file(maybe_rpc_id, node_address, verbose, &input_path)
+                .unwrap_or_else(|error| panic!("response error: {}", error));
         println!(
             "{}",
             serde_json::to_string_pretty(&response).expect("should encode to JSON")

--- a/client/src/get_state_hash.rs
+++ b/client/src/get_state_hash.rs
@@ -31,13 +31,18 @@ impl<'a, 'b> ClientCommand<'a, 'b> for GetStateRootHash {
     }
 
     fn run(matches: &ArgMatches<'_>) {
-        let rpc = common::rpc(matches);
-
+        let maybe_rpc_id = common::rpc_id::get(matches);
+        let node_address = common::node_address::get(matches);
+        let verbose = common::verbose::get(matches);
         let maybe_block_hash = common::block_hash::get(matches);
 
-        let response = rpc
-            .get_state_root_hash(maybe_block_hash)
-            .unwrap_or_else(|error| panic!("response error: {}", error));
+        let response = casper_client::get_state_root_hash(
+            maybe_rpc_id,
+            node_address,
+            verbose,
+            maybe_block_hash,
+        )
+        .unwrap_or_else(|error| panic!("response error: {}", error));
         println!(
             "{}",
             serde_json::to_string_pretty(&response).expect("should encode to JSON")

--- a/client/src/keygen.rs
+++ b/client/src/keygen.rs
@@ -1,4 +1,4 @@
-use std::{path::PathBuf, process};
+use std::process;
 
 use clap::{App, Arg, ArgMatches, SubCommand};
 use lazy_static::lazy_static;
@@ -45,17 +45,16 @@ mod output_dir {
             .display_order(DisplayOrder::OutputDir as usize)
     }
 
-    pub(super) fn get(matches: &ArgMatches) -> PathBuf {
-        matches.value_of(ARG_NAME).unwrap_or_else(|| ".").into()
+    pub(super) fn get(matches: &ArgMatches) -> String {
+        matches
+            .value_of(ARG_NAME)
+            .unwrap_or_else(|| ".")
+            .to_string()
     }
 }
 
 /// Handles providing the arg for and retrieval of the key algorithm.
 mod algorithm {
-    use std::str::FromStr;
-
-    use keygen::Algorithm;
-
     use super::*;
 
     const ARG_NAME: &str = "algorithm";
@@ -76,12 +75,10 @@ mod algorithm {
             .display_order(DisplayOrder::Algorithm as usize)
     }
 
-    pub fn get(matches: &ArgMatches) -> Algorithm {
-        let value = matches
+    pub fn get<'a>(matches: &'a ArgMatches) -> &'a str {
+        matches
             .value_of(ARG_NAME)
-            .unwrap_or_else(|| panic!("should have {} arg", ARG_NAME));
-
-        Algorithm::from_str(value).unwrap_or_else(|_| panic!("Invalid key algorithm"))
+            .unwrap_or_else(|| panic!("should have {} arg", ARG_NAME))
     }
 }
 
@@ -116,7 +113,7 @@ impl<'a, 'b> ClientCommand<'a, 'b> for Keygen {
                 process::exit(1);
             }
             Err(error) => panic!("should write key files: {}", error),
-            Ok(_) => println!("Wrote files to {}", output_dir.display()),
+            Ok(_) => println!("Wrote files to {}", output_dir),
         }
     }
 }

--- a/client/src/query_state.rs
+++ b/client/src/query_state.rs
@@ -2,9 +2,7 @@ use std::{fs, str};
 
 use clap::{App, Arg, ArgMatches, SubCommand};
 
-use casper_client::RpcCall;
 use casper_node::{crypto::asymmetric_key::PublicKey, rpcs::state::GetItem};
-use casper_types::Key;
 
 use crate::{command::ClientCommand, common};
 
@@ -44,39 +42,31 @@ mod key {
             .display_order(DisplayOrder::Key as usize)
     }
 
-    pub(super) fn get(matches: &ArgMatches) -> Key {
+    pub(super) fn get(matches: &ArgMatches) -> String {
         let value = matches
             .value_of(ARG_NAME)
             .unwrap_or_else(|| panic!("should have {} arg", ARG_NAME));
 
-        // Try to parse as a `Key` first.
-        if let Ok(value) = Key::from_formatted_str(value) {
-            return value;
+        // Try to read as a PublicKey PEM file first.
+        if let Ok(public_key) = PublicKey::from_file(value) {
+            return public_key.to_hex();
         }
 
-        // Try to parse from a hex-encoded `PublicKey`, a pem-encoded file then a hex-encoded file.
-        let public_key = if let Ok(public_key) = PublicKey::from_hex(value) {
-            public_key
-        } else if let Ok(public_key) = PublicKey::from_file(value) {
-            public_key
-        } else {
-            let contents = fs::read(value).unwrap_or_else(|_| {
-                panic!(
-                    "failed to parse '{}' as a public key (as a hex string, hex file or pem file), \
-                    account hash, contract address hash or URef",
-                    value
-                )
-            });
-            PublicKey::from_hex(contents).unwrap_or_else(|error| {
+        // Try to read as a hex-encoded PublicKey file next.
+        if let Ok(hex_public_key) = fs::read_to_string(value).map(|contents| {
+            PublicKey::from_hex(contents.as_bytes()).unwrap_or_else(|error| {
                 panic!(
                     "failed to parse '{}' as a hex-encoded public key file: {}",
                     value, error
                 )
-            })
-        };
+            });
+            contents
+        }) {
+            return hex_public_key;
+        }
 
-        // Return the public key as an account hash.
-        Key::Account(public_key.to_account_hash())
+        // Just return the value.
+        value.to_string()
     }
 }
 
@@ -99,11 +89,8 @@ mod path {
             .display_order(DisplayOrder::Path as usize)
     }
 
-    pub(super) fn get(matches: &ArgMatches) -> Vec<String> {
-        match matches.value_of(ARG_NAME) {
-            Some("") | None => return vec![],
-            Some(path) => path.split('/').map(ToString::to_string).collect(),
-        }
+    pub(super) fn get<'a>(matches: &'a ArgMatches) -> &'a str {
+        matches.value_of(ARG_NAME).unwrap_or_default()
     }
 }
 
@@ -128,19 +115,22 @@ impl<'a, 'b> ClientCommand<'a, 'b> for GetItem {
     }
 
     fn run(matches: &ArgMatches<'_>) {
-        let rpc = RpcCall::new(
-            common::rpc_id::get(matches),
-            common::node_address::get(matches),
-            common::verbose::get(matches),
-        );
-
+        let maybe_rpc_id = common::rpc_id::get(matches);
+        let node_address = common::node_address::get(matches);
+        let verbose = common::verbose::get(matches);
         let state_root_hash = common::state_root_hash::get(matches);
         let key = key::get(matches);
         let path = path::get(matches);
 
-        let response = rpc
-            .get_item(state_root_hash, key, path)
-            .unwrap_or_else(|error| panic!("response error: {}", error));
+        let response = casper_client::get_item(
+            maybe_rpc_id,
+            node_address,
+            verbose,
+            state_root_hash,
+            &key,
+            path,
+        )
+        .unwrap_or_else(|error| panic!("response error: {}", error));
         println!(
             "{}",
             serde_json::to_string_pretty(&response).expect("should encode to JSON")

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -75,4 +75,4 @@ pub use runtime_args::{NamedArg, RuntimeArgs};
 pub use semver::{SemVer, SEM_VER_SERIALIZED_LENGTH};
 pub use system_contract_type::SystemContractType;
 pub use transfer_result::{TransferResult, TransferredTo};
-pub use uref::{URef, UREF_ADDR_LENGTH, UREF_SERIALIZED_LENGTH};
+pub use uref::{FromStrError as URefFromStrError, URef, UREF_ADDR_LENGTH, UREF_SERIALIZED_LENGTH};

--- a/types/src/uref.rs
+++ b/types/src/uref.rs
@@ -21,13 +21,20 @@ const FORMATTED_STRING_PREFIX: &str = "uref-";
 /// The address of a [`URef`](types::URef) (unforgeable reference) on the network.
 pub type URefAddr = [u8; UREF_ADDR_LENGTH];
 
+/// Error while parsing a URef from a formatted string.
 #[derive(Debug)]
 pub enum FromStrError {
+    /// Prefix is not "uref-".
     InvalidPrefix,
+    /// No access rights as suffix.
     MissingSuffix,
+    /// Access rights are invalid.
     InvalidAccessRights,
+    /// Failed to decode address portion of URef.
     Hex(base16::DecodeError),
+    /// Failed to parse an int.
     Int(ParseIntError),
+    /// The address portion is the wrong length.
     Address(TryFromSliceError),
 }
 


### PR DESCRIPTION
This changes many of the `RpcCall` methods to take `&str` args rather than domain types.  It also sees these methods made `pub(crate)` and exposed via free functions in the lib's root.

We need to complete this work for the following cases:
* `make-deploy`
* `put-deploy`
* `sign-deploy`
* `transfer`
such that the bin code doesn't need to handle any domain types.

Once this is complete, we can make the `RpcCall` type itself `pub(crate)` too.