### PR TITLE
ECO-697 - refactor all creation into lib

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -427,6 +427,7 @@ dependencies = [
  "clap",
  "futures 0.3.6",
  "hex",
+ "humantime 2.0.1",
  "jsonrpc-lite",
  "lazy_static",
  "rand 0.7.3",

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -25,6 +25,7 @@ casper-types = { version = "0.6.0", path = "../types", features = ["std"] }
 clap = "2.33.1"
 futures = "0.3.5"
 hex = { version = "0.4.2", features = ["serde"] }
+humantime = "2.0.1"
 jsonrpc-lite = "0.5.0"
 lazy_static = "1.4.0"
 rand = "0.7.3"

--- a/client/lib/deploy.rs
+++ b/client/lib/deploy.rs
@@ -104,7 +104,7 @@ pub struct DeployParams {
 }
 
 /// An extension trait that adds some client-specific functionality to `Deploy`.
-pub trait DeployExt {
+pub(super) trait DeployExt {
     /// Constructs a `Deploy`.
     fn with_payment_and_session(
         params: DeployParams,

--- a/client/lib/error.rs
+++ b/client/lib/error.rs
@@ -1,10 +1,11 @@
 use std::{num::ParseIntError, path::PathBuf};
 
+use humantime::{DurationError, TimestampError};
 use jsonrpc_lite::JsonRpc;
 use thiserror::Error;
 
 use casper_node::crypto::Error as CryptoError;
-use casper_types::{bytesrepr::Error as ToBytesError, URefFromStrError};
+use casper_types::{bytesrepr::Error as ToBytesError, UIntParseError, URefFromStrError};
 
 /// Crate-wide Result type wrapper.
 pub(crate) type Result<T> = std::result::Result<T, Error>;
@@ -23,6 +24,18 @@ pub enum Error {
     /// Failed to parse an integer from a string.
     #[error("failed to parse as an integer: {0:?}")]
     FailedToParseInt(#[from] ParseIntError),
+
+    /// Failed to parse a `TimeDiff` from a formatted string.
+    #[error("failed to parse as a time diff: {0:?}")]
+    FailedToParseTimeDiff(DurationError),
+
+    /// Failed to parse a `Timestamp` from a formatted string.
+    #[error("failed to parse as a timestamp: {0:?}")]
+    FailedToParseTimestamp(TimestampError),
+
+    /// Failed to parse uint error.
+    #[error("failed to parse uint {0:?}")]
+    FailedToParseUint(UIntParseError),
 
     /// Failed to get a response from the node.
     #[error("failed to get rpc response: {0}")]
@@ -71,6 +84,10 @@ pub enum Error {
     /// InvalidCLValue error.
     #[error("Invalid CLValue error {0}")]
     InvalidCLValue(String),
+
+    /// Invalid argument.
+    #[error("Invalid argument {0}")]
+    InvalidArgument(String),
 }
 
 impl From<URefFromStrError> for Error {

--- a/client/lib/lib.rs
+++ b/client/lib/lib.rs
@@ -12,20 +12,29 @@
     unused_qualifications
 )]
 
-pub mod cl_type;
 mod deploy;
 mod error;
 mod executable_deploy_item_ext;
-pub mod keygen;
+mod parsing;
 mod rpc;
+
+pub mod cl_type;
+pub mod keygen;
+pub use error::Error;
+
+use std::convert::TryInto;
 
 use jsonrpc_lite::JsonRpc;
 
-pub use deploy::{DeployExt, DeployParams};
-pub use error::Error;
+use casper_execution_engine::core::engine_state::ExecutableDeployItem;
+use casper_node::types::Deploy;
+use casper_types::{UIntParseError, U512};
+
+use deploy::{DeployExt, DeployParams};
+use parsing::none_if_empty;
+use rpc::{RpcCall, TransferTarget};
 use error::Result;
-pub use executable_deploy_item_ext::ExecutableDeployItemExt;
-pub use rpc::{RpcCall, TransferTarget};
+use executable_deploy_item_ext::ExecutableDeployItemExt;
 
 /// Gets a `Deploy` from the node.
 ///
@@ -166,4 +175,437 @@ pub fn get_block(
     maybe_block_hash: &str,
 ) -> Result<JsonRpc> {
     RpcCall::new(maybe_rpc_id, node_address, verbose)?.get_block(maybe_block_hash)
+}
+
+/// Puts a deploy on a node.
+///
+/// * `maybe_rpc_id` is used for RPC-ID as required by the JSON-RPC specification, and is returned
+///   by the node in the corresponding response.  It must be either able to be parsed as a `u32` or
+///   empty.  If empty, a random ID will be assigned.
+/// * `node_address` identifies the network address of the target node's HTTP server, e.g.
+///   `"http://127.0.0.1:7777"`.
+/// * When `verbose` is `true`, the request will be printed to `stdout`.
+/// * `deploy` - Deploy arguments container struct holding options for this deploy. See
+///   `DeployStrParams`.
+/// * `session` - Session arguments container struct holding options for this deploy. See
+///   `SessionStrParams`.
+/// * `payment` - Payment arguments container struct holding options for this deploy. See
+///   `PaymentStrParams`.
+pub fn put_deploy(
+    maybe_rpc_id: &str,
+    node_address: &str,
+    verbose: bool,
+    deploy: DeployStrParams<'_>,
+    session: SessionStrParams<'_>,
+    payment: PaymentStrParams<'_>,
+) -> Result<JsonRpc> {
+    let deploy = Deploy::with_payment_and_session(
+        deploy.try_into()?,
+        payment.try_into()?,
+        session.try_into()?,
+    );
+    RpcCall::new(maybe_rpc_id, node_address, verbose)?.put_deploy(deploy)
+}
+
+/// Make a deploy and output to file or stdout.
+///
+/// * `maybe_rpc_id` is used for RPC-ID as required by the JSON-RPC specification, and is returned
+///   by the node in the corresponding response.  It must be either able to be parsed as a `u32` or
+///   empty.  If empty, a random ID will be assigned.
+/// * `node_address` identifies the network address of the target node's HTTP server, e.g.
+///   `"http://127.0.0.1:7777"`.
+/// * When `verbose` is `true`, the request will be printed to `stdout`.
+/// * `deploy` - Deploy arguments container struct holding options for this deploy. See
+///   `DeployStrParams`.
+/// * `session` - Session arguments container struct holding options for this deploy. See
+///   `SessionStrParams`.
+/// * `payment` - Payment arguments container struct holding options for this deploy. See
+///   `PaymentStrParams`.
+#[allow(clippy::too_many_arguments)]
+pub fn make_deploy(
+    maybe_output_path: &str,
+    deploy: DeployStrParams<'_>,
+    session: SessionStrParams<'_>,
+    payment: PaymentStrParams<'_>,
+) -> Result<()> {
+    Deploy::make_deploy(
+        none_if_empty(maybe_output_path),
+        deploy.try_into()?,
+        payment.try_into()?,
+        session.try_into()?,
+    )
+}
+
+/// Transfers an amount between purses.
+///
+/// * `maybe_rpc_id` is used for RPC-ID as required by the JSON-RPC specification, and is returned
+///   by the node in the corresponding response.  It must be either able to be parsed as a `u32` or
+///   empty.  If empty, a random ID will be assigned.
+/// * `node_address` identifies the network address of the target node's HTTP server, e.g.
+///   `"http://127.0.0.1:7777"`.
+/// * When `verbose` is `true`, the request will be printed to `stdout`.
+/// * `amount` - Specifies the amount to be transferred.
+/// * `maybe_source_purse` - Source purse in the sender's account that this amount will be drawn
+///   from, if it is `""`, it will default to the account's main purse.
+/// * `maybe_target_purse` - Target purse in the sender's account that this amount will be
+///   transferred to.
+/// it is incompatible with `maybe_target_account`.
+/// * `maybe_target_account` - Target account that this amount will be transferred to.
+/// it is incompatible with `maybe_target_purse`.
+/// * `deploy` - Deploy arguments container struct holding options for this deploy.
+#[allow(clippy::too_many_arguments)]
+pub fn transfer(
+    maybe_rpc_id: &str,
+    node_address: &str,
+    verbose: bool,
+    amount: &str,
+    maybe_source_purse: &str,
+    maybe_target_purse: &str,
+    maybe_target_account: &str,
+    deploy: DeployStrParams<'_>,
+) -> Result<JsonRpc> {
+    let target = parsing::get_transfer_target(maybe_target_account, maybe_target_purse)?;
+
+    // transfer always invoke the standard payment
+    let payment = parsing::parse_standard_payment_info(amount)?;
+    let amount = U512::from_dec_str(amount)
+        .map_err(|err| Error::FailedToParseUint(UIntParseError::FromDecStr(err)))?;
+
+    let source_purse = parsing::purse::parse(maybe_source_purse).ok();
+
+    RpcCall::new(maybe_rpc_id, node_address, verbose)?.transfer(
+        amount,
+        source_purse,
+        target,
+        deploy.try_into()?,
+        payment,
+    )
+}
+
+/// Signs a deploy file.
+///
+/// * `input_path` specifies the path to the deploy file.
+/// * `secret_key` specifies the key with which to sign the deploy.
+/// * `maybe_output` specifies the output file, or if left empty, will log it to `stdout`.
+pub fn sign_deploy_file(input: &str, secret_key: &str, maybe_output: &str) -> Result<()> {
+    let input_path = parsing::input::get(input);
+    let secret_key = parsing::secret_key::parse(secret_key)?;
+    let maybe_output = parsing::output::get(maybe_output);
+    Deploy::sign_deploy_file(&input_path, secret_key, maybe_output)
+}
+
+/// Container for `Deploy` construction options.
+pub struct DeployStrParams<'a> {
+    /// Formatted string of `SecretKey`.
+    pub secret_key: &'a str,
+    /// Formatted string of `Timestamp`.
+    pub timestamp: &'a str,
+    /// Formatted string of `ttl`.
+    pub ttl: &'a str,
+    /// List of formatted `DeployHash` strings.
+    pub dependencies: &'a [&'a str],
+    /// Gas price (uint) as a string.
+    pub gas_price: &'a str,
+    /// Chain name.
+    pub chain_name: &'a str,
+}
+
+impl<'a> TryInto<DeployParams> for DeployStrParams<'a> {
+    type Error = Error;
+
+    fn try_into(self) -> Result<DeployParams> {
+        let DeployStrParams {
+            secret_key,
+            timestamp,
+            ttl,
+            gas_price,
+            dependencies,
+            chain_name,
+        } = self;
+        parsing::parse_deploy_params(
+            secret_key,
+            timestamp,
+            ttl,
+            gas_price,
+            dependencies,
+            chain_name,
+        )
+    }
+}
+
+/// Container for payment related arguments.
+#[derive(Default)]
+pub struct PaymentStrParams<'a> {
+    /// Payment amount - all other `payment_*` arguments are ignored and the
+    ///   standard payment contract is used if this is set.
+    pub payment_amount: &'a str,
+    /// Hash of this payment.
+    pub payment_hash: &'a str,
+    /// Name for payment.
+    pub payment_name: &'a str,
+    /// Hash of payment package to be used.
+    pub payment_package_hash: &'a str,
+    /// Name to be used for payment package.
+    pub payment_package_name: &'a str,
+    /// Path to file containing payment code bytes.
+    pub payment_path: &'a str,
+    ///Inline args of the form `NAME:TYPE=VALUE`. Incompatible with
+    ///   `payment_args_complex`.
+    pub payment_args_simple: &'a [&'a str],
+    ///Complex args in file form. Incompatible with `payment_args_simple`.
+    pub payment_args_complex: &'a str,
+    /// Version of this payment.
+    pub payment_version: &'a str,
+    /// Entry point for payment.
+    pub payment_entry_point: &'a str,
+}
+
+impl<'a> TryInto<ExecutableDeployItem> for PaymentStrParams<'a> {
+    type Error = Error;
+
+    fn try_into(self) -> Result<ExecutableDeployItem> {
+        let PaymentStrParams {
+            payment_amount,
+            payment_hash,
+            payment_name,
+            payment_package_hash,
+            payment_package_name,
+            payment_path,
+            payment_args_simple,
+            payment_args_complex,
+            payment_version,
+            payment_entry_point,
+        } = self;
+
+        parsing::parse_payment_info(
+            payment_amount,
+            payment_hash,
+            payment_name,
+            payment_package_hash,
+            payment_package_name,
+            payment_path,
+            payment_args_simple,
+            payment_args_complex,
+            payment_version,
+            payment_entry_point,
+        )
+    }
+}
+
+impl<'a> PaymentStrParams<'a> {
+    /// Construct PaymentParams from a file.
+    pub fn with_path(payment_path: &'a str) -> Self {
+        Self {
+            payment_path,
+            ..Default::default()
+        }
+    }
+
+    /// Construct PaymentParams using an amount.
+    pub fn with_amount(payment_amount: &'a str) -> Self {
+        Self {
+            payment_amount,
+            ..Default::default()
+        }
+    }
+
+    /// Construct PaymentParams with a name.
+    pub fn with_name(
+        payment_name: &'a str,
+        payment_entry_point: &'a str,
+        payment_args_simple: &'a [&'a str],
+        payment_args_complex: &'a str,
+    ) -> Self {
+        Self {
+            payment_name,
+            payment_entry_point,
+            payment_args_simple,
+            payment_args_complex,
+            ..Default::default()
+        }
+    }
+
+    /// Construct PaymentParams with a hash.
+    pub fn with_hash(
+        payment_hash: &'a str,
+        payment_entry_point: &'a str,
+        payment_args_simple: &'a [&'a str],
+        payment_args_complex: &'a str,
+    ) -> Self {
+        Self {
+            payment_hash,
+            payment_entry_point,
+            payment_args_simple,
+            payment_args_complex,
+            ..Default::default()
+        }
+    }
+
+    /// Construct PaymentParams with a package name.
+    pub fn with_package_name(
+        payment_package_name: &'a str,
+        payment_version: &'a str,
+        payment_entry_point: &'a str,
+        payment_args_simple: &'a [&'a str],
+        payment_args_complex: &'a str,
+    ) -> Self {
+        Self {
+            payment_package_name,
+            payment_version,
+            payment_entry_point,
+            payment_args_simple,
+            payment_args_complex,
+            ..Default::default()
+        }
+    }
+
+    /// Construct PaymentParams with a package hash.
+    pub fn with_package_hash(
+        payment_package_hash: &'a str,
+        payment_version: &'a str,
+        payment_entry_point: &'a str,
+        payment_args_simple: &'a [&'a str],
+        payment_args_complex: &'a str,
+    ) -> Self {
+        Self {
+            payment_package_hash,
+            payment_version,
+            payment_entry_point,
+            payment_args_simple,
+            payment_args_complex,
+            ..Default::default()
+        }
+    }
+}
+
+impl<'a> TryInto<ExecutableDeployItem> for SessionStrParams<'a> {
+    type Error = Error;
+
+    fn try_into(self) -> Result<ExecutableDeployItem> {
+        let SessionStrParams {
+            session_hash,
+            session_name,
+            session_package_hash,
+            session_package_name,
+            session_path,
+            session_args_simple,
+            session_args_complex,
+            session_version,
+            session_entry_point,
+        } = self;
+
+        parsing::parse_session_info(
+            session_hash,
+            session_name,
+            session_package_hash,
+            session_package_name,
+            session_path,
+            session_args_simple,
+            session_args_complex,
+            session_version,
+            session_entry_point,
+        )
+    }
+}
+
+/// Container for session related arguments.
+#[derive(Default)]
+pub struct SessionStrParams<'a> {
+    /// Hash for this session.
+    pub session_hash: &'a str,
+    /// Name for this session.
+    pub session_name: &'a str,
+    /// Package hash for this session.
+    pub session_package_hash: &'a str,
+    /// Package Name for this session.
+    pub session_package_name: &'a str,
+    /// Path to file containing session code bytes.
+    pub session_path: &'a str,
+    /// Inline args of the form `NAME:TYPE=VALUE`. Incompatible with
+    ///   `session_args_complex`.
+    pub session_args_simple: &'a [&'a str],
+    /// Complex args in file form. Incompatible with `session_args_simple`.
+    pub session_args_complex: &'a str,
+    /// Version for this session.
+    pub session_version: &'a str,
+    /// Entry point for this session.
+    pub session_entry_point: &'a str,
+}
+
+impl<'a> SessionStrParams<'a> {
+    /// Construct a SessionParams from a file.
+    pub fn with_path(session_path: &'a str) -> Self {
+        Self {
+            session_path,
+            ..Default::default()
+        }
+    }
+
+    /// Construct SessionParams with a name.
+    pub fn with_name(
+        session_name: &'a str,
+        session_entry_point: &'a str,
+        session_args_simple: &'a [&'a str],
+        session_args_complex: &'a str,
+    ) -> Self {
+        Self {
+            session_name,
+            session_entry_point,
+            session_args_simple,
+            session_args_complex,
+            ..Default::default()
+        }
+    }
+
+    /// Construct SessionParams with a hash.
+    pub fn with_hash(
+        session_hash: &'a str,
+        session_entry_point: &'a str,
+        session_args_simple: &'a [&'a str],
+        session_args_complex: &'a str,
+    ) -> Self {
+        Self {
+            session_hash,
+            session_entry_point,
+            session_args_simple,
+            session_args_complex,
+            ..Default::default()
+        }
+    }
+
+    /// Construct SessionParams with a package name.
+    pub fn with_package_name(
+        session_package_name: &'a str,
+        session_version: &'a str,
+        session_entry_point: &'a str,
+        session_args_simple: &'a [&'a str],
+        session_args_complex: &'a str,
+    ) -> Self {
+        Self {
+            session_package_name,
+            session_version,
+            session_entry_point,
+            session_args_simple,
+            session_args_complex,
+            ..Default::default()
+        }
+    }
+
+    /// Construct SessionParams with a package hash.
+    pub fn with_package_hash(
+        session_package_hash: &'a str,
+        session_version: &'a str,
+        session_entry_point: &'a str,
+        session_args_simple: &'a [&'a str],
+        session_args_complex: &'a str,
+    ) -> Self {
+        Self {
+            session_package_hash,
+            session_version,
+            session_entry_point,
+            session_args_simple,
+            session_args_complex,
+            ..Default::default()
+        }
+    }
 }

--- a/client/lib/parsing.rs
+++ b/client/lib/parsing.rs
@@ -1,0 +1,588 @@
+//! This module contains structs and helpers which are used by multiple subcommands related to
+//! creating deploys.
+
+use std::{convert::TryInto, fs, path::PathBuf, str::FromStr};
+
+use serde::{self, Deserialize};
+
+use casper_execution_engine::core::engine_state::executable_deploy_item::ExecutableDeployItem;
+use casper_node::{
+    crypto::{
+        asymmetric_key::{PublicKey as NodePublicKey, SecretKey},
+        hash::Digest,
+    },
+    types::{TimeDiff, Timestamp},
+};
+use casper_types::{
+    bytesrepr, CLType, CLValue, ContractHash, Key, NamedArg, RuntimeArgs, UIntParseError, URef,
+    U512,
+};
+
+use crate::{
+    cl_type,
+    deploy::DeployParams,
+    error::{Error, Result},
+    ExecutableDeployItemExt, TransferTarget,
+};
+
+pub(super) fn none_if_empty(value: &'_ str) -> Option<&'_ str> {
+    if value.is_empty() {
+        return None;
+    }
+    Some(value)
+}
+/// Handles providing the arg for and retrieval of the timestamp.
+mod timestamp {
+    use super::*;
+
+    pub(crate) fn parse(value: &str) -> Result<Timestamp> {
+        Timestamp::from_str(value).map_err(Error::FailedToParseTimestamp)
+    }
+}
+
+/// Handles providing the arg for and retrieval of the time to live.
+mod ttl {
+    use super::*;
+
+    pub(crate) fn parse(value: &str) -> Result<TimeDiff> {
+        TimeDiff::from_str(value).map_err(Error::FailedToParseTimeDiff)
+    }
+}
+
+/// Handles providing the arg for and retrieval of the gas price.
+mod gas_price {
+    use super::*;
+
+    pub(crate) fn parse(value: &str) -> Result<u64> {
+        Ok(value.parse::<u64>()?)
+    }
+}
+
+/// Handles providing the arg for and retrieval of the deploy dependencies.
+mod dependencies {
+    use super::*;
+    use casper_node::types::DeployHash;
+
+    pub(crate) fn parse(values: &[&str]) -> Result<Vec<DeployHash>> {
+        let mut hashes = Vec::with_capacity(values.len());
+        for value in values {
+            let digest = Digest::from_hex(value)?;
+            hashes.push(DeployHash::new(digest))
+        }
+        Ok(hashes)
+    }
+}
+
+/// Handles providing the arg for and retrieval of the chain name.
+mod chain_name {
+    pub(crate) fn parse(value: &str) -> String {
+        value.to_string()
+    }
+}
+
+/// Handles providing the arg for and retrieval of the session code bytes.
+mod session_path {
+    use super::*;
+
+    pub(crate) fn parse(value: &str) -> Result<Vec<u8>> {
+        Ok(fs::read(value)?)
+    }
+}
+
+/// Handles providing the arg for and retrieval of simple session and payment args.
+mod arg_simple {
+    use super::*;
+
+    const ARG_VALUE_NAME: &str = "NAME:TYPE='VALUE'";
+
+    pub(crate) mod session {
+        use super::*;
+
+        pub fn parse(values: &[&str]) -> Option<RuntimeArgs> {
+            if values.is_empty() {
+                None
+            } else {
+                Some(get(values))
+            }
+        }
+    }
+
+    pub(crate) mod payment {
+        use super::*;
+
+        pub fn parse(values: &[&str]) -> Option<RuntimeArgs> {
+            if values.is_empty() {
+                None
+            } else {
+                Some(get(values))
+            }
+        }
+    }
+
+    fn get(values: &[&str]) -> RuntimeArgs {
+        let mut runtime_args = RuntimeArgs::new();
+        for arg in values {
+            let parts = split_arg(arg);
+            parts_to_cl_value(parts, &mut runtime_args);
+        }
+        runtime_args
+    }
+
+    /// Splits a single arg of the form `NAME:TYPE='VALUE'` into its constituent parts.
+    fn split_arg(arg: &str) -> (&str, CLType, &str) {
+        let parts: Vec<_> = arg.splitn(3, &[':', '='][..]).collect();
+        if parts.len() != 3 {
+            panic!("arg {} should be formatted as {}", arg, ARG_VALUE_NAME);
+        }
+        let cl_type = cl_type::parse(&parts[1]).unwrap_or_else(|_| {
+            panic!(
+                "unknown variant {}, expected one of {}",
+                parts[1],
+                cl_type::supported_cl_type_list()
+            )
+        });
+        (parts[0], cl_type, parts[2].trim_matches('\''))
+    }
+
+    /// Insert a value built from a single arg which has been split into its constituent parts.
+    fn parts_to_cl_value(parts: (&str, CLType, &str), runtime_args: &mut RuntimeArgs) {
+        let (name, cl_type, value) = parts;
+        let cl_value = cl_type::parse_value(cl_type, value)
+            .unwrap_or_else(|error| panic!("error parsing cl_value {}", error));
+        runtime_args.insert_cl_value(name, cl_value);
+    }
+}
+
+/// Handles providing the arg for and retrieval of complex session and payment args.  These are read
+/// in from a file.
+mod args_complex {
+    use super::*;
+
+    #[derive(Debug, Deserialize)]
+    #[serde(rename_all = "snake_case")]
+    enum DeployArgValue {
+        /// Contains `CLValue` serialized into bytes in base16 form.
+        #[serde(deserialize_with = "hex::deserialize")]
+        RawBytes(Vec<u8>),
+    }
+
+    #[derive(Debug, Deserialize)]
+    #[serde(rename_all = "snake_case")]
+    struct DeployArg {
+        /// Deploy argument's name.
+        name: String,
+        value: DeployArgValue,
+    }
+
+    impl From<DeployArgValue> for CLValue {
+        fn from(value: DeployArgValue) -> Self {
+            match value {
+                DeployArgValue::RawBytes(bytes) => bytesrepr::deserialize(bytes)
+                    .unwrap_or_else(|error| panic!("should deserialize deploy arg: {}", error)),
+            }
+        }
+    }
+
+    impl From<DeployArg> for NamedArg {
+        fn from(deploy_arg: DeployArg) -> Self {
+            let cl_value = deploy_arg
+                .value
+                .try_into()
+                .unwrap_or_else(|error| panic!("should serialize deploy arg: {}", error));
+            NamedArg::new(deploy_arg.name, cl_value)
+        }
+    }
+
+    pub mod session {
+        use super::*;
+
+        pub fn parse(path: &str) -> Result<RuntimeArgs> {
+            if path.is_empty() {
+                return Err(Error::InvalidArgument(path.to_string()));
+            }
+            get(path)
+        }
+    }
+
+    pub mod payment {
+        use super::*;
+
+        pub fn parse(path: &str) -> Result<RuntimeArgs> {
+            if path.is_empty() {
+                return Err(Error::InvalidArgument(path.to_string()));
+            }
+            get(path)
+        }
+    }
+
+    fn get(path: &str) -> Result<RuntimeArgs> {
+        let bytes = fs::read(path)?;
+        // Received structured args in JSON format.
+        let args: Vec<DeployArg> = serde_json::from_slice(&bytes)?;
+        // Convert JSON deploy args into vector of named args.
+        let mut named_args = Vec::with_capacity(args.len());
+        for arg in args {
+            named_args.push(arg.into());
+        }
+        Ok(RuntimeArgs::from(named_args))
+    }
+}
+
+/// Handles providing the arg for and retrieval of the payment code bytes.
+mod payment_path {
+    use super::*;
+
+    pub fn parse(path: &str) -> Result<Vec<u8>> {
+        Ok(fs::read(path)?)
+    }
+}
+
+/// Handles providing the arg for and retrieval of the payment-amount arg.
+mod standard_payment {
+
+    use super::*;
+
+    const STANDARD_PAYMENT_ARG_NAME: &str = "amount";
+
+    pub fn parse(value: &str) -> Result<RuntimeArgs> {
+        let arg = U512::from_dec_str(value)
+            .map_err(|err| Error::FailedToParseUint(UIntParseError::FromDecStr(err)))?;
+        let mut runtime_args = RuntimeArgs::new();
+        runtime_args.insert(STANDARD_PAYMENT_ARG_NAME, arg);
+        Ok(runtime_args)
+    }
+}
+
+pub(super) mod secret_key {
+    use super::*;
+
+    pub fn parse(value: &str) -> Result<SecretKey> {
+        let path = PathBuf::from(value);
+        SecretKey::from_file(path).map_err(Error::CryptoError)
+    }
+}
+
+fn args_from_simple_or_complex(
+    simple: Option<RuntimeArgs>,
+    complex: Option<RuntimeArgs>,
+) -> RuntimeArgs {
+    // We can have exactly zero or one of the two as `Some`.
+    match (simple, complex) {
+        (Some(args), None) | (None, Some(args)) => args,
+        (None, None) => RuntimeArgs::new(),
+        (Some(_), Some(_)) => unreachable!("should not have both simple and complex args"),
+    }
+}
+
+pub(super) fn parse_deploy_params(
+    secret_key: &str,
+    timestamp: &str,
+    ttl: &str,
+    gas_price: &str,
+    dependencies: &[&str],
+    chain_name: &str,
+) -> Result<DeployParams> {
+    let secret_key = secret_key::parse(secret_key)?;
+    let timestamp = timestamp::parse(timestamp)?;
+    let ttl = ttl::parse(ttl)?;
+    let gas_price = gas_price::parse(gas_price)?;
+    let dependencies = dependencies::parse(dependencies)?;
+    let chain_name = chain_name::parse(chain_name);
+
+    Ok(DeployParams {
+        timestamp,
+        ttl,
+        gas_price,
+        dependencies,
+        chain_name,
+        secret_key,
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) fn parse_session_info(
+    session_hash: &str,
+    session_name: &str,
+    package_hash: &str,
+    package_name: &str,
+    session_path: &str,
+    session_args: &[&str],
+    session_args_complex: &str,
+    version: &str,
+    entry_point: &str,
+) -> Result<ExecutableDeployItem> {
+    let session_args = args_from_simple_or_complex(
+        arg_simple::session::parse(session_args),
+        args_complex::session::parse(session_args_complex).ok(),
+    );
+
+    if let Some(session_name) = session_name::parse(session_name) {
+        return ExecutableDeployItem::new_stored_contract_by_name(
+            session_name,
+            session_entry_point::get(entry_point)
+                .ok_or_else(|| Error::InvalidArgument(entry_point.to_string()))?,
+            session_args,
+        );
+    }
+
+    if let Ok(session_hash) = session_hash::parse(session_hash) {
+        return ExecutableDeployItem::new_stored_contract_by_hash(
+            session_hash,
+            session_entry_point::get(entry_point)
+                .ok_or_else(|| Error::InvalidArgument(entry_point.to_string()))?,
+            session_args,
+        );
+    }
+
+    let version = session_version::parse(version).ok();
+    if let Some(package_name) = session_package_name::get(package_name) {
+        return ExecutableDeployItem::new_stored_versioned_contract_by_name(
+            package_name,
+            version,
+            session_entry_point::get(entry_point)
+                .ok_or_else(|| Error::InvalidArgument(entry_point.to_string()))?,
+            session_args,
+        );
+    }
+
+    if let Ok(package_hash) = session_package_hash::parse(package_hash) {
+        return ExecutableDeployItem::new_stored_versioned_contract_by_hash(
+            package_hash,
+            version,
+            session_entry_point::get(entry_point)
+                .ok_or_else(|| Error::InvalidArgument(entry_point.to_string()))?,
+            session_args,
+        );
+    }
+
+    let module_bytes = session_path::parse(session_path)?;
+    ExecutableDeployItem::new_module_bytes(module_bytes, session_args)
+}
+
+pub(super) fn parse_standard_payment_info(
+    standard_payment_amount: &str,
+) -> Result<ExecutableDeployItem> {
+    let payment_args = standard_payment::parse(standard_payment_amount)?;
+    ExecutableDeployItem::new_module_bytes(vec![], payment_args)
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) fn parse_payment_info(
+    standard_payment_amount: &str,
+    payment_hash: &str,
+    payment_name: &str,
+    package_hash: &str,
+    package_name: &str,
+    payment_path: &str,
+    payment_args: &[&str],
+    payment_args_complex: &str,
+    payment_version: &str,
+    entry_point: &str,
+) -> Result<ExecutableDeployItem> {
+    if let Ok(payment_args) = standard_payment::parse(standard_payment_amount) {
+        return ExecutableDeployItem::new_module_bytes(vec![], payment_args);
+    }
+
+    let payment_args = args_from_simple_or_complex(
+        arg_simple::payment::parse(payment_args),
+        args_complex::payment::parse(payment_args_complex).ok(),
+    );
+
+    if let Some(payment_name) = payment_name::get(payment_name) {
+        return ExecutableDeployItem::new_stored_contract_by_name(
+            payment_name,
+            payment_entry_point::get(entry_point)
+                .ok_or_else(|| Error::InvalidArgument(entry_point.to_string()))?,
+            payment_args,
+        );
+    }
+
+    if let Ok(payment_hash) = payment_hash::parse(payment_hash) {
+        return ExecutableDeployItem::new_stored_contract_by_hash(
+            payment_hash,
+            payment_entry_point::get(entry_point)
+                .ok_or_else(|| Error::InvalidArgument(entry_point.to_string()))?,
+            payment_args,
+        );
+    }
+
+    let version = payment_version::parse(payment_version).ok();
+    if let Some(package_name) = payment_package_name::get(package_name) {
+        return ExecutableDeployItem::new_stored_versioned_contract_by_name(
+            package_name,
+            version,
+            payment_entry_point::get(entry_point)
+                .ok_or_else(|| Error::InvalidArgument(entry_point.to_string()))?,
+            payment_args,
+        );
+    }
+
+    if let Ok(package_hash) = payment_package_hash::parse(package_hash) {
+        return ExecutableDeployItem::new_stored_versioned_contract_by_hash(
+            package_hash,
+            version,
+            payment_entry_point::get(entry_point)
+                .ok_or_else(|| Error::InvalidArgument(entry_point.to_string()))?,
+            payment_args,
+        );
+    }
+
+    let module_bytes = payment_path::parse(payment_path)?;
+    ExecutableDeployItem::new_module_bytes(module_bytes, payment_args)
+}
+
+pub(crate) fn get_transfer_target(
+    target_account: &str,
+    target_purse: &str,
+) -> Result<TransferTarget> {
+    let account = target_account::parse(target_account).ok();
+    let purse = purse::parse(target_purse).ok();
+    let target = match (purse, account) {
+        (Some(purse), _) => TransferTarget::OwnPurse(purse),
+        (None, Some(account)) => TransferTarget::Account(account),
+        _ => {
+            return Err(Error::InvalidArgument(format!(
+                "Invalid arguments to get_transfer_target {} {}",
+                target_purse, target_account
+            )))
+        }
+    };
+    Ok(target)
+}
+
+pub(super) mod output {
+    use super::*;
+
+    pub fn get(value: &str) -> Option<&str> {
+        none_if_empty(value)
+    }
+}
+
+pub(super) mod input {
+    pub fn get(value: &str) -> &str {
+        value
+    }
+}
+
+fn parse_contract_hash(value: &str) -> Result<ContractHash> {
+    if let Ok(digest) = Digest::from_hex(value) {
+        return Ok(digest.to_array());
+    }
+    if let Ok(Key::Hash(hash)) = Key::from_formatted_str(value) {
+        return Ok(hash);
+    }
+    Err(Error::FailedToParseKey)
+}
+
+mod session_hash {
+    use super::*;
+
+    pub fn parse(value: &str) -> Result<ContractHash> {
+        parse_contract_hash(value)
+    }
+}
+
+mod session_name {
+    use super::*;
+
+    pub fn parse(value: &str) -> Option<String> {
+        none_if_empty(value).map(str::to_string)
+    }
+}
+
+mod session_package_hash {
+    use super::*;
+    pub fn parse(value: &str) -> Result<ContractHash> {
+        parse_contract_hash(value)
+    }
+}
+
+mod session_package_name {
+    use super::*;
+
+    pub fn get(value: &str) -> Option<String> {
+        none_if_empty(value).map(str::to_string)
+    }
+}
+
+mod session_entry_point {
+    use super::*;
+
+    pub fn get(value: &str) -> Option<String> {
+        none_if_empty(value).map(str::to_string)
+    }
+}
+
+mod session_version {
+    use super::*;
+
+    pub fn parse(value: &str) -> Result<u32> {
+        Ok(value.parse::<u32>()?)
+    }
+}
+
+mod payment_hash {
+    use super::*;
+
+    pub fn parse(value: &str) -> Result<ContractHash> {
+        parse_contract_hash(value)
+    }
+}
+
+mod payment_name {
+    use super::*;
+
+    pub fn get(value: &str) -> Option<String> {
+        none_if_empty(value).map(str::to_string)
+    }
+}
+
+mod payment_package_hash {
+    use super::*;
+
+    pub fn parse(value: &str) -> Result<ContractHash> {
+        parse_contract_hash(value)
+    }
+}
+
+mod payment_package_name {
+    use super::*;
+
+    pub fn get(value: &str) -> Option<String> {
+        none_if_empty(value).map(str::to_string)
+    }
+}
+
+mod payment_entry_point {
+    use super::*;
+
+    pub fn get(value: &str) -> Option<String> {
+        none_if_empty(value).map(str::to_string)
+    }
+}
+
+mod payment_version {
+    use super::*;
+
+    pub fn parse(value: &str) -> Result<u32> {
+        Ok(value.parse::<u32>()?)
+    }
+}
+
+mod target_account {
+
+    use super::*;
+
+    pub(crate) fn parse(value: &str) -> Result<NodePublicKey> {
+        Ok(NodePublicKey::from_hex(value)?)
+    }
+}
+
+pub(super) mod purse {
+
+    use super::*;
+
+    pub(crate) fn parse(value: &str) -> Result<URef> {
+        Ok(URef::from_formatted_str(value)?)
+    }
+}

--- a/client/lib/rpc.rs
+++ b/client/lib/rpc.rs
@@ -25,7 +25,7 @@ use crate::{
 };
 
 /// Target for a given transfer.
-pub enum TransferTarget {
+pub(crate) enum TransferTarget {
     /// Transfer to another purse within an account.
     OwnPurse(URef),
     /// Transfer to another account.
@@ -34,7 +34,7 @@ pub enum TransferTarget {
 
 /// Struct representing a single JSON-RPC call to the casper node.
 #[derive(Debug, Default)]
-pub struct RpcCall {
+pub(crate) struct RpcCall {
     // TODO - If/when https://github.com/AtsukiTak/warp-json-rpc/pull/1 is merged and published,
     //        change `rpc_id` to a `jsonrpc_lite::Id`.
     rpc_id: u32,
@@ -126,12 +126,6 @@ impl RpcCall {
         GetBalance::request_with_map_params(self, params)
     }
 
-    /// Transfers an amount between purses.
-    ///
-    /// - `amount` - Specifies the amount to be transferred.
-    /// - `source_purse` - Source purse in the sender's account that this amount will be drawn from,
-    ///   if it is `None`, it will default to the account's main purse.
-    /// - `target` - Target for this transfer - see (TransferTarget)[TransferTarget].
     pub fn transfer(
         self,
         amount: U512,

--- a/client/src/common.rs
+++ b/client/src/common.rs
@@ -1,9 +1,4 @@
-use std::{fs, path::PathBuf};
-
 use clap::{Arg, ArgMatches};
-
-use casper_client::RpcCall;
-use casper_node::crypto::asymmetric_key::SecretKey;
 
 pub const ARG_PATH: &str = "PATH";
 pub const ARG_HEX_STRING: &str = "HEX STRING";
@@ -104,13 +99,10 @@ pub mod secret_key {
             .display_order(order)
     }
 
-    pub fn get(matches: &ArgMatches) -> SecretKey {
-        let path = PathBuf::from(
-            matches
-                .value_of(ARG_NAME)
-                .unwrap_or_else(|| panic!("should have {} arg", ARG_NAME)),
-        );
-        SecretKey::from_file(path).expect("should parse secret key pem file")
+    pub fn get<'a>(matches: &'a ArgMatches) -> &'a str {
+        matches
+            .value_of(ARG_NAME)
+            .unwrap_or_else(|| panic!("should have {} arg", ARG_NAME))
     }
 }
 
@@ -194,17 +186,4 @@ pub mod block_hash {
     pub(crate) fn get<'a>(matches: &'a ArgMatches) -> &'a str {
         matches.value_of(ARG_NAME).unwrap_or_default()
     }
-}
-
-pub fn read_file(path: &str) -> Vec<u8> {
-    fs::read(path).unwrap_or_else(|error| panic!("should read {}: {}", path, error))
-}
-
-pub fn rpc(matches: &ArgMatches) -> RpcCall {
-    RpcCall::new(
-        rpc_id::get(matches),
-        node_address::get(matches),
-        verbose::get(matches),
-    )
-    .unwrap_or_else(|error| panic!("should create RPC: {}", error))
 }

--- a/client/src/deploy/make.rs
+++ b/client/src/deploy/make.rs
@@ -1,10 +1,8 @@
+use casper_client::{DeployStrParams, PaymentStrParams, SessionStrParams};
 use clap::{App, ArgMatches, SubCommand};
 
-use casper_client::DeployExt;
-use casper_node::types::Deploy;
-
 use super::creation_common;
-use crate::command::ClientCommand;
+use crate::{command::ClientCommand, common};
 
 pub struct MakeDeploy;
 
@@ -26,11 +24,71 @@ impl<'a, 'b> ClientCommand<'a, 'b> for MakeDeploy {
 
     fn run(matches: &ArgMatches<'_>) {
         creation_common::show_arg_examples_and_exit_if_required(matches);
-        let session = creation_common::parse_session_info(matches);
-        let payment = creation_common::parse_payment_info(matches);
-        let deploy_params = creation_common::parse_deploy_params(matches);
+
+        let secret_key = common::secret_key::get(matches);
+        let timestamp = creation_common::timestamp::get(matches);
+        let ttl = creation_common::ttl::get(matches);
+        let gas_price = creation_common::gas_price::get(matches);
+        let dependencies = creation_common::dependencies::get(matches);
+        let chain_name = creation_common::chain_name::get(matches);
+
+        let session_args_simple = creation_common::arg_simple::session::get(matches);
+        let session_args_complex = creation_common::args_complex::session::get(matches);
+        let session_name = creation_common::session_name::get(matches);
+        let session_hash = creation_common::session_hash::get(matches);
+        let session_version = creation_common::session_version::get(matches);
+        let session_package_name = creation_common::session_package_name::get(matches);
+        let session_package_hash = creation_common::session_package_hash::get(matches);
+        let session_path = creation_common::session_path::get(matches);
+        let session_entry_point = creation_common::session_entry_point::get(matches);
+
+        let payment_amount = creation_common::standard_payment_amount::get(matches);
+        let payment_args_simple = creation_common::arg_simple::payment::get(matches);
+        let payment_args_complex = creation_common::args_complex::payment::get(matches);
+        let payment_name = creation_common::payment_name::get(matches);
+        let payment_hash = creation_common::payment_hash::get(matches);
+        let payment_version = creation_common::payment_version::get(matches);
+        let payment_package_name = creation_common::payment_package_name::get(matches);
+        let payment_package_hash = creation_common::payment_package_hash::get(matches);
+        let payment_path = creation_common::payment_path::get(matches);
+        let payment_entry_point = creation_common::payment_entry_point::get(matches);
+
         let maybe_output_path = creation_common::output::get(matches);
-        Deploy::make_deploy(maybe_output_path, deploy_params, payment, session)
-            .unwrap_or_else(|err| panic!("unable to make deploy {:?}", err));
+
+        casper_client::make_deploy(
+            maybe_output_path,
+            DeployStrParams {
+                secret_key,
+                timestamp,
+                ttl,
+                dependencies: &dependencies,
+                gas_price,
+                chain_name,
+            },
+            SessionStrParams {
+                session_hash,
+                session_name,
+                session_package_hash,
+                session_package_name,
+                session_path,
+                session_args_simple: &session_args_simple,
+                session_args_complex,
+                session_version,
+                session_entry_point,
+            },
+            PaymentStrParams {
+                payment_amount,
+                payment_hash,
+                payment_name,
+                payment_package_hash,
+                payment_package_name,
+                payment_path,
+                payment_args_simple: &payment_args_simple,
+                payment_args_complex,
+                payment_version,
+                payment_entry_point,
+            }
+        )
+        .unwrap_or_else(|err| panic!("unable to make deploy {:?}", err));
     }
 }

--- a/client/src/deploy/put.rs
+++ b/client/src/deploy/put.rs
@@ -1,3 +1,4 @@
+use casper_client::{DeployStrParams, PaymentStrParams, SessionStrParams};
 use clap::{App, ArgMatches, SubCommand};
 
 use casper_node::rpcs::account::PutDeploy;
@@ -23,17 +24,74 @@ impl<'a, 'b> ClientCommand<'a, 'b> for PutDeploy {
     fn run(matches: &ArgMatches<'_>) {
         creation_common::show_arg_examples_and_exit_if_required(matches);
 
-        let rpc = common::rpc(matches);
+        let maybe_rpc_id = common::rpc_id::get(matches);
+        let node_address = common::node_address::get(matches);
+        let verbose = common::verbose::get(matches);
 
-        let session = creation_common::parse_session_info(matches);
-        let deploy = creation_common::parse_deploy(matches, session);
+        let secret_key = common::secret_key::get(matches);
+        let timestamp = creation_common::timestamp::get(matches);
+        let ttl = creation_common::ttl::get(matches);
+        let gas_price = creation_common::gas_price::get(matches);
+        let dependencies = creation_common::dependencies::get(matches);
+        let chain_name = creation_common::chain_name::get(matches);
 
-        let response = rpc
-            .put_deploy(deploy)
-            .unwrap_or_else(|error| panic!("response error: {}", error));
-        println!(
-            "{}",
-            serde_json::to_string_pretty(&response).expect("should encode to JSON")
-        );
+        let session_args_simple = creation_common::arg_simple::session::get(matches);
+        let session_args_complex = creation_common::args_complex::session::get(matches);
+        let session_name = creation_common::session_package_name::get(matches);
+        let session_hash = creation_common::session_hash::get(matches);
+        let session_version = creation_common::session_version::get(matches);
+        let session_package_name = creation_common::session_package_name::get(matches);
+        let session_package_hash = creation_common::session_package_hash::get(matches);
+        let session_path = creation_common::session_path::get(matches);
+        let session_entry_point = creation_common::session_entry_point::get(matches);
+
+        let payment_amount = creation_common::standard_payment_amount::get(matches);
+        let payment_args_simple = creation_common::arg_simple::payment::get(matches);
+        let payment_args_complex = creation_common::args_complex::payment::get(matches);
+        let payment_name = creation_common::payment_name::get(matches);
+        let payment_hash = creation_common::payment_hash::get(matches);
+        let payment_version = creation_common::payment_version::get(matches);
+        let payment_package_name = creation_common::payment_package_name::get(matches);
+        let payment_package_hash = creation_common::payment_package_hash::get(matches);
+        let payment_path = creation_common::payment_path::get(matches);
+        let payment_entry_point = creation_common::payment_entry_point::get(matches);
+
+        casper_client::put_deploy(
+            maybe_rpc_id,
+            node_address,
+            verbose,
+            DeployStrParams {
+                secret_key,
+                timestamp,
+                ttl,
+                dependencies: &dependencies,
+                gas_price,
+                chain_name,
+            },
+            SessionStrParams {
+                session_hash,
+                session_name,
+                session_package_hash,
+                session_package_name,
+                session_path,
+                session_args_simple: &session_args_simple,
+                session_args_complex,
+                session_version,
+                session_entry_point,
+            },
+            PaymentStrParams {
+                payment_amount,
+                payment_hash,
+                payment_name,
+                payment_package_hash,
+                payment_package_name,
+                payment_path,
+                payment_args_simple: &payment_args_simple,
+                payment_args_complex,
+                payment_version,
+                payment_entry_point,
+            },
+        )
+        .unwrap_or_else(|err| panic!("unable to put deploy {:?}", err));
     }
 }

--- a/client/src/deploy/sign.rs
+++ b/client/src/deploy/sign.rs
@@ -1,8 +1,5 @@
 use clap::{App, ArgMatches, SubCommand};
 
-use casper_client::DeployExt;
-use casper_node::types::Deploy;
-
 use super::creation_common;
 use crate::{command::ClientCommand, common};
 
@@ -28,7 +25,7 @@ impl<'a, 'b> ClientCommand<'a, 'b> for SignDeploy {
         let input_path = creation_common::input::get(matches);
         let secret_key = common::secret_key::get(matches);
         let maybe_output = creation_common::output::get(matches);
-        Deploy::sign_deploy_file(&input_path, secret_key, maybe_output).unwrap_or_else(
+        casper_client::sign_deploy_file(&input_path, secret_key, maybe_output).unwrap_or_else(
             move |err| panic!("error writing deploy to {:?}: {}", maybe_output, err),
         );
     }


### PR DESCRIPTION
This PR moves all deploy-creation and related parsing out into the `casper_client` library.