### PR TITLE
Rename read_trie to get_trie

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3660,17 +3660,11 @@ dependencies = [
  "hex",
  "jsonrpc-lite",
  "lmdb",
- "log",
- "num-rational 0.4.0",
- "num-traits",
- "once_cell",
- "rand 0.8.4",
  "reqwest",
  "serde",
  "serde_json",
  "structopt",
  "tokio",
- "version-sync",
  "walkdir",
 ]
 

--- a/execution_engine/src/core/engine_state/mod.rs
+++ b/execution_engine/src/core/engine_state/mod.rs
@@ -97,7 +97,7 @@ pub const WASMLESS_TRANSFER_FIXED_GAS_PRICE: u64 = 1;
 pub struct EngineState<S> {
     config: EngineConfig,
     system_contract_cache: SystemContractCache,
-    pub state: S,
+    state: S,
 }
 
 impl EngineState<LmdbGlobalState> {
@@ -1656,7 +1656,7 @@ where
             .map_err(Error::from)
     }
 
-    pub fn read_trie(
+    pub fn get_trie(
         &self,
         correlation_id: CorrelationId,
         trie_key: Digest,
@@ -1665,7 +1665,7 @@ where
         Error: From<S::Error>,
     {
         self.state
-            .read_trie(correlation_id, &trie_key)
+            .get_trie(correlation_id, &trie_key)
             .map_err(Error::from)
     }
 

--- a/execution_engine/src/shared/host_function_costs.rs
+++ b/execution_engine/src/shared/host_function_costs.rs
@@ -84,9 +84,7 @@ pub(crate) const DEFAULT_HOST_FUNCTION_NEW_DICTIONARY: HostFunction<[Cost; 1]> =
 ///
 /// Total gas cost is equal to `cost` + sum of each argument weight multiplied by the byte size of
 /// the data.
-#[derive(
-    Copy, Clone, PartialEq, Eq, Deserialize, Serialize, Debug, DataSize, schemars::JsonSchema,
-)]
+#[derive(Copy, Clone, PartialEq, Eq, Deserialize, Serialize, Debug, DataSize)]
 pub struct HostFunction<T> {
     /// How much user is charged for cost only
     cost: Cost,
@@ -191,9 +189,7 @@ where
     }
 }
 
-#[derive(
-    Copy, Clone, PartialEq, Eq, Serialize, Deserialize, Debug, DataSize, schemars::JsonSchema,
-)]
+#[derive(Copy, Clone, PartialEq, Eq, Serialize, Deserialize, Debug, DataSize)]
 pub struct HostFunctionCosts {
     pub read_value: HostFunction<[Cost; 3]>,
     #[serde(alias = "read_value_local")]

--- a/execution_engine/src/shared/opcode_costs.rs
+++ b/execution_engine/src/shared/opcode_costs.rs
@@ -29,9 +29,7 @@ const NUM_FIELDS: usize = 17;
 pub const OPCODE_COSTS_SERIALIZED_LENGTH: usize = NUM_FIELDS * U32_SERIALIZED_LENGTH;
 
 // Taken (partially) from parity-ethereum
-#[derive(
-    Copy, Clone, PartialEq, Eq, Serialize, Deserialize, Debug, DataSize, schemars::JsonSchema,
-)]
+#[derive(Copy, Clone, PartialEq, Eq, Serialize, Deserialize, Debug, DataSize)]
 pub struct OpcodeCosts {
     /// Bit operations multiplier.
     pub bit: u32,

--- a/execution_engine/src/shared/storage_costs.rs
+++ b/execution_engine/src/shared/storage_costs.rs
@@ -9,9 +9,7 @@ use casper_types::{
 
 pub const DEFAULT_GAS_PER_BYTE_COST: u32 = 625_000;
 
-#[derive(
-    Copy, Clone, PartialEq, Eq, Serialize, Deserialize, Debug, DataSize, schemars::JsonSchema,
-)]
+#[derive(Copy, Clone, PartialEq, Eq, Serialize, Deserialize, Debug, DataSize)]
 pub struct StorageCosts {
     /// Gas charged per byte stored in the global state.
     gas_per_byte: u32,

--- a/execution_engine/src/shared/system_config.rs
+++ b/execution_engine/src/shared/system_config.rs
@@ -16,9 +16,7 @@ use self::{
 
 pub const DEFAULT_WASMLESS_TRANSFER_COST: u32 = 250_000_000;
 
-#[derive(
-    Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Debug, DataSize, schemars::JsonSchema,
-)]
+#[derive(Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Debug, DataSize)]
 pub struct SystemConfig {
     /// Wasmless transfer cost expressed in gas.
     wasmless_transfer_cost: u32,

--- a/execution_engine/src/shared/system_config/auction_costs.rs
+++ b/execution_engine/src/shared/system_config/auction_costs.rs
@@ -18,9 +18,7 @@ pub const DEFAULT_READ_ERA_ID_COST: u32 = 10_000;
 pub const DEFAULT_ACTIVATE_BID_COST: u32 = 10_000;
 
 /// Description of costs of calling auction entrypoints.
-#[derive(
-    Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Debug, DataSize, schemars::JsonSchema,
-)]
+#[derive(Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Debug, DataSize)]
 pub struct AuctionCosts {
     pub get_era_validators: u32,
     pub read_seigniorage_recipients: u32,

--- a/execution_engine/src/shared/system_config/handle_payment_costs.rs
+++ b/execution_engine/src/shared/system_config/handle_payment_costs.rs
@@ -9,9 +9,7 @@ pub const DEFAULT_GET_REFUND_PURSE_COST: u32 = 10_000;
 pub const DEFAULT_FINALIZE_PAYMENT_COST: u32 = 10_000;
 
 /// Description of costs of calling handle payment entrypoints.
-#[derive(
-    Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Debug, DataSize, schemars::JsonSchema,
-)]
+#[derive(Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Debug, DataSize)]
 pub struct HandlePaymentCosts {
     pub get_payment_purse: u32,
     pub set_refund_purse: u32,

--- a/execution_engine/src/shared/system_config/mint_costs.rs
+++ b/execution_engine/src/shared/system_config/mint_costs.rs
@@ -11,9 +11,7 @@ pub const DEFAULT_TRANSFER_COST: u32 = 10_000;
 pub const DEFAULT_READ_BASE_ROUND_REWARD_COST: u32 = 10_000;
 
 /// Description of costs of calling mint entrypoints.
-#[derive(
-    Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Debug, DataSize, schemars::JsonSchema,
-)]
+#[derive(Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Debug, DataSize)]
 pub struct MintCosts {
     pub mint: u32,
     pub reduce_total_supply: u32,

--- a/execution_engine/src/shared/system_config/standard_payment_costs.rs
+++ b/execution_engine/src/shared/system_config/standard_payment_costs.rs
@@ -6,9 +6,7 @@ use serde::{Deserialize, Serialize};
 pub const DEFAULT_PAY_COST: u32 = 10_000;
 
 /// Description of costs of calling standard payment entrypoints.
-#[derive(
-    Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Debug, DataSize, schemars::JsonSchema,
-)]
+#[derive(Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Debug, DataSize)]
 pub struct StandardPaymentCosts {
     pub pay: u32,
 }

--- a/execution_engine/src/shared/wasm_config.rs
+++ b/execution_engine/src/shared/wasm_config.rs
@@ -11,9 +11,7 @@ use super::{
 pub const DEFAULT_WASM_MAX_MEMORY: u32 = 64;
 pub const DEFAULT_MAX_STACK_HEIGHT: u32 = 64 * 1024;
 
-#[derive(
-    Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Debug, DataSize, schemars::JsonSchema,
-)]
+#[derive(Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Debug, DataSize)]
 pub struct WasmConfig {
     /// Maximum amount of a heap memory (represented in 64kb pages) each contract can use.
     pub max_memory: u32,

--- a/execution_engine/src/storage/global_state/in_memory.rs
+++ b/execution_engine/src/storage/global_state/in_memory.rs
@@ -235,7 +235,7 @@ impl StateProvider for InMemoryGlobalState {
         self.empty_root_hash
     }
 
-    fn read_trie(
+    fn get_trie(
         &self,
         _correlation_id: CorrelationId,
         trie_key: &Digest,

--- a/execution_engine/src/storage/global_state/mod.rs
+++ b/execution_engine/src/storage/global_state/mod.rs
@@ -96,7 +96,7 @@ pub trait StateProvider {
     fn empty_root(&self) -> Digest;
 
     /// Reads a `Trie` from the state if it is present
-    fn read_trie(
+    fn get_trie(
         &self,
         correlation_id: CorrelationId,
         trie_key: &Digest,

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -13,16 +13,16 @@ All notable changes to this project will be documented in this file.  The format
 ## [Unreleased]
 
 ### Added
-* Added `enable_manual_sync` boolean option to `[contract_runtime]` in the config.toml which enables manual LMDB sync.
-* Added new event to the main SSE server stream accessed via `<IP:Port>/events/main` which emits hashes of expired deploys.
-* Added `contract_runtime_execute_block` histogram tracking execution time of a whole block.
-* Long running events now log their event type.
+* Add `enable_manual_sync` boolean option to `[contract_runtime]` in the config.toml which enables manual LMDB sync.
+* Add new event to the main SSE server stream accessed via `<IP:Port>/events/main` which emits hashes of expired deploys.
+* Add `contract_runtime_execute_block` histogram tracking execution time of a whole block.
+* Long-running events now log their event type.
 * Individual weights for traffic throttling can now be set through the configuration value
   `network.estimator_weights`.
-* Added `consensus.highway.max_request_batch_size` configuration parameter. Defaults to 20.
+* Add `consensus.highway.max_request_batch_size` configuration parameter. Defaults to 20.
 * New histogram metrics `deploy_acceptor_accepted_deploy` and `deploy_acceptor_rejected_deploy` that track how long the initial verification took.
-* Added gzip content negotiation (using accept-encoding header) to rpc endpoints.
-* Adds `read_trie` json-rpc endpoint and related `retrieve-state` binary in `utils/`.
+* Add gzip content negotiation (using accept-encoding header) to rpc endpoints.
+* Add `state_get_trie` JSON-RPC endpoint.
 
 ### Changed
 * The following Highway timers are now separate, configurable, and optional (if the entry is not in the config, the timer is never called):

--- a/node/src/components/contract_runtime.rs
+++ b/node/src/components/contract_runtime.rs
@@ -130,7 +130,7 @@ pub(crate) struct ContractRuntimeMetrics {
     get_bids: Histogram,
     missing_trie_keys: Histogram,
     put_trie: Histogram,
-    read_trie: Histogram,
+    get_trie: Histogram,
     chain_height: IntGauge,
     exec_block: Histogram,
 }
@@ -166,8 +166,8 @@ const GET_ERA_VALIDATORS_NAME: &str = "contract_runtime_get_era_validators";
 const GET_ERA_VALIDATORS_HELP: &str = "tracking run of engine_state.get_era_validators in seconds.";
 const GET_BIDS_NAME: &str = "contract_runtime_get_bids";
 const GET_BIDS_HELP: &str = "tracking run of engine_state.get_bids in seconds.";
-const READ_TRIE_NAME: &str = "contract_runtime_read_trie";
-const READ_TRIE_HELP: &str = "tracking run of engine_state.read_trie in seconds.";
+const GET_TRIE_NAME: &str = "contract_runtime_get_trie";
+const GET_TRIE_HELP: &str = "tracking run of engine_state.get_trie in seconds.";
 const PUT_TRIE_NAME: &str = "contract_runtime_put_trie";
 const PUT_TRIE_HELP: &str = "tracking run of engine_state.put_trie in seconds.";
 const MISSING_TRIE_KEYS_NAME: &str = "contract_runtime_missing_trie_keys";
@@ -224,7 +224,7 @@ impl ContractRuntimeMetrics {
                 GET_ERA_VALIDATORS_HELP,
             )?,
             get_bids: register_histogram_metric(registry, GET_BIDS_NAME, GET_BIDS_HELP)?,
-            read_trie: register_histogram_metric(registry, READ_TRIE_NAME, READ_TRIE_HELP)?,
+            get_trie: register_histogram_metric(registry, GET_TRIE_NAME, GET_TRIE_HELP)?,
             put_trie: register_histogram_metric(registry, PUT_TRIE_NAME, PUT_TRIE_HELP)?,
             missing_trie_keys: register_histogram_metric(
                 registry,
@@ -351,19 +351,19 @@ where
                 }
                 .ignore()
             }
-            ContractRuntimeRequest::ReadTrie {
+            ContractRuntimeRequest::GetTrie {
                 trie_key,
                 responder,
             } => {
-                trace!(?trie_key, "read_trie request");
+                trace!(?trie_key, "get_trie request");
                 let engine_state = Arc::clone(&self.engine_state);
                 let metrics = Arc::clone(&self.metrics);
                 async move {
                     let correlation_id = CorrelationId::new();
                     let start = Instant::now();
-                    let result = engine_state.read_trie(correlation_id, trie_key);
-                    metrics.read_trie.observe(start.elapsed().as_secs_f64());
-                    trace!(?result, "read_trie response");
+                    let result = engine_state.get_trie(correlation_id, trie_key);
+                    metrics.get_trie.observe(start.elapsed().as_secs_f64());
+                    trace!(?result, "get_trie response");
                     responder.respond(result).await
                 }
                 .ignore()

--- a/node/src/components/fetcher.rs
+++ b/node/src/components/fetcher.rs
@@ -294,10 +294,10 @@ impl ItemFetcher<GlobalStorageTrie> for Fetcher<GlobalStorageTrie> {
         peer: NodeId,
     ) -> Effects<Event<GlobalStorageTrie>> {
         async move {
-            let maybe_trie = match effect_builder.read_trie(id).await {
+            let maybe_trie = match effect_builder.get_trie(id).await {
                 Ok(maybe_trie) => maybe_trie,
                 Err(error) => {
-                    error!(?error, "read_trie_request");
+                    error!(?error, "get_trie_request");
                     None
                 }
             };

--- a/node/src/components/rpc_server/http_server.rs
+++ b/node/src/components/rpc_server/http_server.rs
@@ -71,8 +71,7 @@ pub(super) async fn run<REv: ReactorEventT>(
         rpcs::chain::GetEraInfoBySwitchBlock::create_filter(effect_builder, api_version);
     let rpc_get_auction_info =
         rpcs::state::GetAuctionInfo::create_filter(effect_builder, api_version);
-    let rpc_read_trie =
-        rpcs::state::read_trie::ReadTrie::create_filter(effect_builder, api_version);
+    let rpc_get_trie = rpcs::state::GetTrie::create_filter(effect_builder, api_version);
     let rpc_get_rpcs = rpcs::docs::ListRpcs::create_filter(effect_builder, api_version);
     let rpc_get_dictionary_item =
         rpcs::state::GetDictionaryItem::create_filter(effect_builder, api_version);
@@ -106,7 +105,7 @@ pub(super) async fn run<REv: ReactorEventT>(
         .or(rpc_get_account_info)
         .or(rpc_get_rpcs)
         .or(rpc_get_dictionary_item)
-        .or(rpc_read_trie)
+        .or(rpc_get_trie)
         .or(rpc_query_global_state)
         .or(unknown_method)
         .or(parse_failure);

--- a/node/src/components/rpc_server/rpcs.rs
+++ b/node/src/components/rpc_server/rpcs.rs
@@ -48,7 +48,7 @@ enum ErrorCode {
     InvalidDeploy = -32008,
     NoSuchAccount = -32009,
     FailedToGetDictionaryURef = -32010,
-    ReadTrie = -32011,
+    FailedToGetTrie = -32011,
 }
 
 #[derive(Debug)]

--- a/node/src/effect.rs
+++ b/node/src/effect.rs
@@ -944,8 +944,8 @@ impl<REv> EffectBuilder<REv> {
             .await
     }
 
-    /// Read a trie by its hash key
-    pub(crate) async fn read_trie(
+    /// Get a trie by its hash key.
+    pub(crate) async fn get_trie(
         self,
         trie_key: Digest,
     ) -> Result<Option<Trie<Key, StoredValue>>, engine_state::Error>
@@ -953,7 +953,7 @@ impl<REv> EffectBuilder<REv> {
         REv: From<ContractRuntimeRequest>,
     {
         self.make_request(
-            |responder| ContractRuntimeRequest::ReadTrie {
+            |responder| ContractRuntimeRequest::GetTrie {
                 trie_key,
                 responder,
             },

--- a/node/src/effect/requests.rs
+++ b/node/src/effect/requests.rs
@@ -752,9 +752,9 @@ pub(crate) enum ContractRuntimeRequest {
         /// Responder,
         responder: Responder<Result<bool, GetEraValidatorsError>>,
     },
-    /// Read a trie by its hash key
-    ReadTrie {
-        /// The hash of the value to get from the `TrieStore`
+    /// Get a trie by its hash key.
+    GetTrie {
+        /// The hash of the value to get from the `TrieStore`.
         trie_key: Digest,
         /// Responder to call with the result.
         responder: Responder<Result<Option<Trie<Key, StoredValue>>, engine_state::Error>>,
@@ -831,7 +831,7 @@ impl Display for ContractRuntimeRequest {
             } => {
                 write!(formatter, "is {} bonded in era {}", public_key, era_id)
             }
-            ContractRuntimeRequest::ReadTrie { trie_key, .. } => {
+            ContractRuntimeRequest::GetTrie { trie_key, .. } => {
                 write!(formatter, "get trie_key: {}", trie_key)
             }
             ContractRuntimeRequest::PutTrie { trie, .. } => {

--- a/node/src/types.rs
+++ b/node/src/types.rs
@@ -21,10 +21,10 @@ use rand_chacha::ChaCha20Rng;
 
 pub use block::{
     json_compatibility::{JsonBlock, JsonBlockHeader},
-    Block, BlockBody, BlockHash, BlockHeader, BlockSignatures, FinalitySignature, FinalizedBlock,
+    Block, BlockBody, BlockHash, BlockHeader, BlockSignatures, FinalitySignature,
     HashingAlgorithmVersion, MerkleBlockBody, MerkleBlockBodyPart, MerkleLinkedListNode,
 };
-pub(crate) use block::{BlockByHeight, BlockHeaderWithMetadata, BlockPayload};
+pub(crate) use block::{BlockByHeight, BlockHeaderWithMetadata, BlockPayload, FinalizedBlock};
 pub(crate) use chainspec::ActivationPoint;
 pub use chainspec::Chainspec;
 pub use datasize::DataSize;

--- a/node/src/types/json_compatibility.rs
+++ b/node/src/types/json_compatibility.rs
@@ -5,30 +5,12 @@ mod auction_state;
 mod contracts;
 mod stored_value;
 
-use hex_buffer_serde::{Hex, HexForm};
-use serde::{Deserialize, Serialize};
+use casper_types::{contracts::NamedKeys, NamedKey};
 
 pub use account::Account;
 pub use auction_state::AuctionState;
-use casper_types::{contracts::NamedKeys, NamedKey};
 pub use contracts::{Contract, ContractPackage};
 pub use stored_value::StoredValue;
-
-/// Newtype wrapper for serializing Vec<u8> as base16.
-#[derive(Serialize, Deserialize, Debug)]
-pub struct Base16Blob(#[serde(with = "HexForm")] Vec<u8>);
-
-impl From<Vec<u8>> for Base16Blob {
-    fn from(bytes: Vec<u8>) -> Self {
-        Self(bytes)
-    }
-}
-
-impl From<Base16Blob> for Vec<u8> {
-    fn from(blob: Base16Blob) -> Self {
-        blob.0
-    }
-}
 
 /// A helper function to change NamedKeys into a Vec<NamedKey>
 pub fn vectorize(keys: &NamedKeys) -> Vec<NamedKey> {

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -38,7 +38,7 @@ mod gas;
 #[cfg(any(feature = "gens", test))]
 pub mod gens;
 mod json_pretty_printer;
-pub mod key;
+mod key;
 mod motes;
 mod named_key;
 mod phase;
@@ -75,8 +75,8 @@ pub use gas::Gas;
 pub use json_pretty_printer::json_pretty_print;
 #[doc(inline)]
 pub use key::{
-    DictionaryAddr, HashAddr, Key, KeyTag, BLAKE2B_DIGEST_LENGTH, DICTIONARY_ITEM_KEY_MAX_LENGTH,
-    KEY_DICTIONARY_LENGTH, KEY_HASH_LENGTH,
+    DictionaryAddr, FromStrError as KeyFromStrError, HashAddr, Key, KeyTag, BLAKE2B_DIGEST_LENGTH,
+    DICTIONARY_ITEM_KEY_MAX_LENGTH, KEY_DICTIONARY_LENGTH, KEY_HASH_LENGTH,
 };
 pub use motes::Motes;
 pub use named_key::NamedKey;

--- a/utils/retrieve-state/Cargo.toml
+++ b/utils/retrieve-state/Cargo.toml
@@ -4,27 +4,19 @@ version = "0.1.0"
 authors = ["Daniel Werner <dan@casperlabs.io>"]
 edition = "2018"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
+anyhow = "1"
 casper-contract = { path = "../../smart_contracts/contract", default-features = false, features = ["std"] }
-casper-execution-engine = { path = "../../execution_engine", features = ["gens"] }
-casper-types = { path = "../../types", default-features = false, features = ["std"] }
-casper-node = { path = "../../node" }
+casper-execution-engine = { path = "../../execution_engine" }
 casper-hashing = { path = "../../hashing" }
+casper-node = { path = "../../node" }
+casper-types = { path = "../../types", default-features = false, features = ["std"] }
+hex = "0.4.3"
+jsonrpc-lite = "0.5.0"
 lmdb = "0.8.0"
-log = "0.4.8"
-num-rational = "0.4.0"
-num-traits = "0.2.10"
-once_cell = "1.5.2"
-rand = "0.8.3"
-anyhow = "*"
-hex="*"
-jsonrpc-lite = "*"
 reqwest = { version = "0.11.1", features = ["json", "gzip"] }
-serde_json = "*"
-serde = "*"
+serde = "1"
+serde_json = "1"
 structopt = "0.3.22"
-tokio = { version = "1", features = ["macros", "net", "rt-multi-thread", "sync", "time"] }
-version-sync = "0.9"
+tokio = { version = "1", features = ["fs", "macros", "rt-multi-thread"] }
 walkdir = "2"


### PR DESCRIPTION
This mainly renames "read trie" to "get trie" and changes the RPC method to `state_get_trie` for consistency.

There are some other nitpicks addressed, with the only bugfix being the schemars attribute for `GetTrieResult::maybe_trie_bytes` being changed from `String` to `Option<String>`.